### PR TITLE
Fix local Asset Identifier return type 

### DIFF
--- a/Classes/AssetSource/CantoAssetProxy.php
+++ b/Classes/AssetSource/CantoAssetProxy.php
@@ -272,7 +272,7 @@ final class CantoAssetProxy implements AssetProxyInterface, HasRemoteOriginalInt
     public function getLocalAssetIdentifier(): ?string
     {
         $importedAsset = $this->importedAssetRepository->findOneByAssetSourceIdentifierAndRemoteAssetIdentifier($this->assetSource->getIdentifier(), $this->identifier);
-        return ($importedAsset instanceof ImportedAsset ? $importedAsset->getLocalAssetIdentifier() : null);
+        return ($importedAsset instanceof ImportedAsset ? $importedAsset->getLocalAssetIdentifier() : '');
     }
 
     /**


### PR DESCRIPTION
To make the Canto package work with the new Neos UI, getLocalAssetIdentifier expects a string as return and will not accept null. 
