### PR TITLE
BUGFIX: New Media UI throws error when no search results are found

### DIFF
--- a/Classes/AssetSource/CantoAssetProxyQuery.php
+++ b/Classes/AssetSource/CantoAssetProxyQuery.php
@@ -199,7 +199,7 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
         $response = $this->sendSearchRequest($this->limit, $this->orderings);
         $responseObject = \GuzzleHttp\json_decode($response->getBody());
 
-        if(isset($responseObject->results) && !empty($responseObject->results)){
+        if (isset($responseObject->results) && is_array($responseObject->results)) {
             foreach ($responseObject->results as $rawAsset) {
                 $assetIdentifier = $rawAsset->scheme . '-' . $rawAsset->id;
 


### PR DESCRIPTION
### How to reproduce
1. In the new Media UI, search with a searchTerm where no asset exists, for example 'blubediblubblub'

#### Expected behavior
No assets are loaded and the UI displays a message

#### Actual behavior
The search throws an Error in the JS Console: [GraphQL error]: Message: Exception #1 in line 203 of /application/Data/Temporary/Development/SubContextBeach/SubContextInstance/Cache/Code/Flow_Object_Classes/Flownative_Canto_AssetSource_CantoAssetProxyQuery.php: Notice: Undefined property: stdClass::$results in /application/Data/Temporary/Development/SubContextBeach/SubContextInstance/Cache/Code/Flow_Object_Classes/Flownative_Canto_AssetSource_CantoAssetProxyQuery.php line 203

### What I did 
To not have the error, I am checking if $responseObject->results exists and is not empty. The page then stops throwing errors. 