### PR TITLE
Bugfix: Catch errors in connecting to Canto Client

### DIFF
--- a/Classes/AssetSource/CantoAssetProxyRepository.php
+++ b/Classes/AssetSource/CantoAssetProxyRepository.php
@@ -79,8 +79,12 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
         if ($cacheEntry) {
             $responseObject = \GuzzleHttp\json_decode($cacheEntry);
         } else {
-            $response = $this->assetSource->getCantoClient()->getFile($identifier);
-            $responseObject = \GuzzleHttp\json_decode($response->getBody());
+            try {
+                $response = $this->assetSource->getCantoClient()->getFile($identifier);
+                $responseObject = \GuzzleHttp\json_decode($response->getBody());
+            } catch (\Exception $e) {
+                throw new AssetNotFoundException('Asset not found', 1526636260);
+            }
         }
 
         if (!$responseObject instanceof \stdClass) {


### PR DESCRIPTION
When removing unused Assets with ./flow media:removeunused Canto throws an error: 'Security context not initialized and client credentials use not allowed'. 

Apparently Neos sends a signal to Canto via the dispatcher with 'ASSET_REMOVED'. This calls the function getAssetProxy in Canto. Here Canto tries to authenticate but then throws an error since we are in the command line. With the try catch Neos gets a correct answer and the command runs. I am not sure if this is the correct way. 

I could not find out why Neos triggers the ASSET_REMOVED in readonly sources and we should perhaps change  that. 