### PR TITLE
Add isAuthenticated() method to the CantoClient

### DIFF
--- a/Classes/Service/CantoClient.php
+++ b/Classes/Service/CantoClient.php
@@ -406,4 +406,26 @@ final class CantoClient
 
         return $this->httpClient->send($this->getAuthenticatedRequest($this->authorization, $uriPathAndQuery, $method, $bodyFields));
     }
+
+    /**
+     * Checks if the current user is authenticated and has a valid access-token.
+     *
+     * @return bool
+     */
+    public function isAuthenticated(): bool
+    {
+        $oAuthClient = new CantoOAuthClient($this->serviceName);
+
+        if ($this->securityContext->isInitialized()) {
+            $account = $this->securityContext->getAccount();
+            $accountAuthorization = $account ? $this->accountAuthorizationRepository->findOneByFlowAccountIdentifier($account->getAccountIdentifier()) : null;
+            $authorization = $accountAuthorization instanceof AccountAuthorization ? $oAuthClient->getAuthorization($accountAuthorization->getAuthorizationId()) : null;
+
+            if ($authorization !== null && ($authorization->getAccessToken() && !$authorization->getAccessToken()->hasExpired())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/Classes/Service/CantoClient.php
+++ b/Classes/Service/CantoClient.php
@@ -408,7 +408,9 @@ final class CantoClient
     }
 
     /**
-     * Checks if the current user is authenticated and has a valid access-token.
+     * Checks if the current account fetched from the security context has a valid access-token.
+     *
+     * If the security context is not initialized, no account is found or no valid access-token exists, false is returned.
      *
      * @return bool
      */


### PR DESCRIPTION
The client always redirects to the authentication notice page when the client is not authenticated. When you are in a different context than a backend module, it is not always the best case to get the redirect. So, this method adds to check if the client is authenticated without the redirect.