### PR TITLE
FEATURE: Use actual Canto tags

### DIFF
--- a/Classes/AssetSource/CantoAssetProxy.php
+++ b/Classes/AssetSource/CantoAssetProxy.php
@@ -109,9 +109,6 @@ final class CantoAssetProxy implements AssetProxyInterface, HasRemoteOriginalInt
     protected $thumbnailService;
 
     /**
-     * @param stdClass $jsonObject
-     * @param CantoAssetSource $assetSource
-     * @return static
      * @throws Exception
      */
     public static function fromJsonObject(stdClass $jsonObject, CantoAssetSource $assetSource): CantoAssetProxy
@@ -140,99 +137,61 @@ final class CantoAssetProxy implements AssetProxyInterface, HasRemoteOriginalInt
         return $assetProxy;
     }
 
-    /**
-     * @return AssetSourceInterface
-     */
     public function getAssetSource(): AssetSourceInterface
     {
         return $this->assetSource;
     }
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string
     {
         return $this->identifier;
     }
 
-    /**
-     * @return string
-     */
     public function getLabel(): string
     {
         return $this->label;
     }
 
-    /**
-     * @return string
-     */
     public function getFilename(): string
     {
         return $this->filename;
     }
 
-    /**
-     * @return \DateTime
-     */
     public function getLastModified(): \DateTime
     {
         return $this->lastModified;
     }
 
-    /**
-     * @return int
-     */
     public function getFileSize(): int
     {
         return $this->fileSize;
     }
 
-    /**
-     * @return string
-     */
     public function getMediaType(): string
     {
         return $this->mediaType;
     }
 
-    /**
-     * @param string $propertyName
-     * @return bool
-     */
     public function hasIptcProperty(string $propertyName): bool
     {
         return isset($this->iptcProperties[$propertyName]);
     }
 
-    /**
-     * @param string $propertyName
-     * @return string
-     */
     public function getIptcProperty(string $propertyName): string
     {
         return $this->iptcProperties[$propertyName] ?? '';
     }
 
-    /**
-     * @return array
-     */
     public function getIptcProperties(): array
     {
         return $this->iptcProperties;
     }
 
-    /**
-     * @return int|null
-     */
     public function getWidthInPixels(): ?int
     {
         return $this->widthInPixels;
     }
 
-    /**
-     * @return int|null
-     */
     public function getHeightInPixels(): ?int
     {
         return $this->heightInPixels;
@@ -286,17 +245,11 @@ final class CantoAssetProxy implements AssetProxyInterface, HasRemoteOriginalInt
         return ($importedAsset instanceof ImportedAsset ? $importedAsset->getLocalAssetIdentifier() : null);
     }
 
-    /**
-     * @return array
-     */
     public function getTags(): array
     {
         return $this->tags;
     }
 
-    /**
-     * @return bool
-     */
     public function isImported(): bool
     {
         $importedAsset = $this->importedAssetRepository->findOneByAssetSourceIdentifierAndRemoteAssetIdentifier($this->assetSource->getIdentifier(), $this->identifier);

--- a/Classes/AssetSource/CantoAssetProxyQuery.php
+++ b/Classes/AssetSource/CantoAssetProxyQuery.php
@@ -32,11 +32,6 @@ use Psr\Log\LoggerInterface as SystemLoggerInterface;
 final class CantoAssetProxyQuery implements AssetProxyQueryInterface
 {
     /**
-     * @var CantoAssetSource
-     */
-    private $assetSource;
-
-    /**
      * @var string
      */
     private $searchTerm = '';
@@ -91,70 +86,45 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
     /**
      * @param CantoAssetSource $assetSource
      */
-    public function __construct(CantoAssetSource $assetSource)
+    public function __construct(private CantoAssetSource $assetSource)
     {
-        $this->assetSource = $assetSource;
     }
 
-    /**
-     * @param int $offset
-     */
     public function setOffset(int $offset): void
     {
         $this->offset = $offset;
     }
 
-    /**
-     * @return int
-     */
     public function getOffset(): int
     {
         return $this->offset;
     }
 
-    /**
-     * @param int $limit
-     */
     public function setLimit(int $limit): void
     {
         $this->limit = $limit;
     }
 
-    /**
-     * @return int
-     */
     public function getLimit(): int
     {
         return $this->limit;
     }
 
-    /**
-     * @param string $searchTerm
-     */
     public function setSearchTerm(string $searchTerm): void
     {
         $this->searchTerm = $searchTerm;
     }
 
-    /**
-     * @return string
-     */
     public function getSearchTerm(): string
     {
         return $this->searchTerm;
     }
 
-    /**
-     * @param Tag $tag
-     */
     public function setActiveTag(Tag $tag): void
     {
         $this->activeTag = $tag;
     }
 
-    /**
-     * @return Tag
-     */
     public function getActiveTag(): Tag
     {
         return $this->activeTag;
@@ -168,56 +138,37 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
         $this->activeAssetCollection = $assetCollection;
     }
 
-    /**
-     * @return AssetCollection|null
-     */
     public function getActiveAssetCollection(): ?AssetCollection
     {
         return $this->activeAssetCollection;
     }
 
-    /**
-     * @param string $assetTypeFilter
-     */
     public function setAssetTypeFilter(string $assetTypeFilter): void
     {
         $this->assetTypeFilter = $assetTypeFilter;
     }
 
-    /**
-     * @return string
-     */
     public function getAssetTypeFilter(): string
     {
         return $this->assetTypeFilter;
     }
 
-    /**
-     * @return array
-     */
     public function getOrderings(): array
     {
         return $this->orderings;
     }
 
-    /**
-     * @param array $orderings
-     */
     public function setOrderings(array $orderings): void
     {
         $this->orderings = $orderings;
     }
 
-    /**
-     * @return AssetProxyQueryResultInterface
-     */
     public function execute(): AssetProxyQueryResultInterface
     {
         return new CantoAssetProxyQueryResult($this);
     }
 
     /**
-     * @return int
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException
@@ -256,9 +207,6 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
     }
 
     /**
-     * @param int $limit
-     * @param array $orderings
-     * @return Response
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException
@@ -293,7 +241,6 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
     }
 
     /**
-     * @return void
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException
@@ -327,7 +274,6 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
     }
 
     /**
-     * @return void
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException

--- a/Classes/AssetSource/CantoAssetProxyQuery.php
+++ b/Classes/AssetSource/CantoAssetProxyQuery.php
@@ -271,6 +271,10 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
                 }
             }
         }
+
+        if (!empty($this->mapping['tags'])) {
+            $this->tagQuery .= '&tags="' . $this->activeTag->getLabel() . '"';
+        }
     }
 
     /**

--- a/Classes/AssetSource/CantoAssetProxyQuery.php
+++ b/Classes/AssetSource/CantoAssetProxyQuery.php
@@ -176,7 +176,7 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
     public function count(): int
     {
         $response = $this->sendSearchRequest(1, []);
-        $responseObject = \GuzzleHttp\json_decode($response->getBody());
+        $responseObject = \GuzzleHttp\json_decode($response->getBody()->getContents());
         return $responseObject->found ?? 0;
     }
 
@@ -192,7 +192,7 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
     {
         $assetProxies = [];
         $response = $this->sendSearchRequest($this->limit, $this->orderings);
-        $responseObject = \GuzzleHttp\json_decode($response->getBody());
+        $responseObject = \GuzzleHttp\json_decode($response->getBody()->getContents());
 
         if (isset($responseObject->results) && is_array($responseObject->results)) {
             foreach ($responseObject->results as $rawAsset) {

--- a/Classes/AssetSource/CantoAssetProxyQueryResult.php
+++ b/Classes/AssetSource/CantoAssetProxyQueryResult.php
@@ -28,11 +28,6 @@ use Neos\Media\Domain\Model\AssetSource\AssetProxyQueryResultInterface;
 class CantoAssetProxyQueryResult implements AssetProxyQueryResultInterface
 {
     /**
-     * @var CantoAssetProxyQuery
-     */
-    private $query;
-
-    /**
      * @var array
      */
     private $assetProxies;
@@ -50,13 +45,11 @@ class CantoAssetProxyQueryResult implements AssetProxyQueryResultInterface
     /**
      * @param CantoAssetProxyQuery $query
      */
-    public function __construct(CantoAssetProxyQuery $query)
+    public function __construct(private CantoAssetProxyQuery $query)
     {
-        $this->query = $query;
     }
 
     /**
-     * @return void
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws CacheException
@@ -71,16 +64,12 @@ class CantoAssetProxyQueryResult implements AssetProxyQueryResultInterface
         }
     }
 
-    /**
-     * @return AssetProxyQueryInterface
-     */
     public function getQuery(): AssetProxyQueryInterface
     {
         return clone $this->query;
     }
 
     /**
-     * @return AssetProxyInterface|null
      * @throws CacheException
      * @throws GuzzleException
      * @throws InvalidDataException
@@ -160,7 +149,6 @@ class CantoAssetProxyQueryResult implements AssetProxyQueryResultInterface
     }
 
     /**
-     * @return int
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException

--- a/Classes/AssetSource/CantoAssetProxyRepository.php
+++ b/Classes/AssetSource/CantoAssetProxyRepository.php
@@ -35,11 +35,6 @@ use Neos\Media\Domain\Model\Tag;
 class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, SupportsSortingInterface, SupportsTaggingInterface, SupportsCollectionsInterface
 {
     /**
-     * @var CantoAssetSource
-     */
-    private $assetSource;
-
-    /**
      * @var AssetCollection
      */
     private $activeAssetCollection;
@@ -47,9 +42,8 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
     /**
      * @param CantoAssetSource $assetSource
      */
-    public function __construct(CantoAssetSource $assetSource)
+    public function __construct(private CantoAssetSource $assetSource)
     {
-        $this->assetSource = $assetSource;
     }
 
     /**
@@ -63,8 +57,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
     private $orderings = [];
 
     /**
-     * @param string $identifier
-     * @return AssetProxyInterface
      * @throws AssetNotFoundException
      * @throws OAuthClientException
      * @throws GuzzleException
@@ -100,9 +92,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
         $this->assetTypeFilter = (string)$assetType ?: 'All';
     }
 
-    /**
-     * @return AssetProxyQueryResultInterface
-     */
     public function findAll(): AssetProxyQueryResultInterface
     {
         $query = new CantoAssetProxyQuery($this->assetSource);
@@ -111,10 +100,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
         return new CantoAssetProxyQueryResult($query);
     }
 
-    /**
-     * @param string $searchTerm
-     * @return AssetProxyQueryResultInterface
-     */
     public function findBySearchTerm(string $searchTerm): AssetProxyQueryResultInterface
     {
         $query = new CantoAssetProxyQuery($this->assetSource);
@@ -124,10 +109,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
         return new CantoAssetProxyQueryResult($query);
     }
 
-    /**
-     * @param Tag $tag
-     * @return AssetProxyQueryResultInterface
-     */
     public function findByTag(Tag $tag): AssetProxyQueryResultInterface
     {
         $query = new CantoAssetProxyQuery($this->assetSource);
@@ -139,7 +120,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
     }
 
     /**
-     * @return AssetProxyQueryResultInterface
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException
@@ -155,7 +135,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
     }
 
     /**
-     * @return int
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException
@@ -174,7 +153,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
      * )
      *
      * @param array $orderings The property names to order by by default
-     * @return void
      * @api
      */
     public function orderBy(array $orderings): void
@@ -183,7 +161,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
     }
 
     /**
-     * @return int
      * @throws OAuthClientException
      * @throws GuzzleException
      * @throws AuthenticationFailedException
@@ -200,7 +177,6 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
 
     /**
      * @param AssetCollection|null $assetCollection
-     * @return void
      */
     public function filterByCollection(AssetCollection $assetCollection = null): void
     {

--- a/Classes/AssetSource/CantoAssetProxyRepository.php
+++ b/Classes/AssetSource/CantoAssetProxyRepository.php
@@ -165,6 +165,21 @@ class CantoAssetProxyRepository implements AssetProxyRepositoryInterface, Suppor
      * @throws GuzzleException
      * @throws AuthenticationFailedException
      */
+    public function countByTag(Tag $tag): int
+    {
+        $query = new CantoAssetProxyQuery($this->assetSource);
+        $query->setActiveTag($tag);
+        $query->setActiveAssetCollection($this->activeAssetCollection);
+        $query->setAssetTypeFilter($this->assetTypeFilter);
+        $query->setOrderings($this->orderings);
+        return $query->count();
+    }
+
+    /**
+     * @throws OAuthClientException
+     * @throws GuzzleException
+     * @throws AuthenticationFailedException
+     */
     public function countUntagged(): int
     {
         $query = new CantoAssetProxyQuery($this->assetSource);

--- a/Classes/AssetSource/CantoAssetSource.php
+++ b/Classes/AssetSource/CantoAssetSource.php
@@ -68,11 +68,6 @@ class CantoAssetSource implements AssetSourceInterface
     private $cantoClient;
 
     /**
-     * @var array
-     */
-    private $assetSourceOptions;
-
-    /**
      * @var string
      */
     private $iconPath;
@@ -97,14 +92,13 @@ class CantoAssetSource implements AssetSourceInterface
      * @param string $assetSourceIdentifier
      * @param array $assetSourceOptions
      */
-    public function __construct(string $assetSourceIdentifier, array $assetSourceOptions)
+    public function __construct(string $assetSourceIdentifier, private array $assetSourceOptions)
     {
         if (preg_match('/^[a-z][a-z0-9-]{0,62}[a-z]$/', $assetSourceIdentifier) !== 1) {
             throw new \InvalidArgumentException(sprintf('Invalid asset source identifier "%s". The identifier must match /^[a-z][a-z0-9-]{0,62}[a-z]$/', $assetSourceIdentifier), 1607085585);
         }
 
         $this->assetSourceIdentifier = $assetSourceIdentifier;
-        $this->assetSourceOptions = $assetSourceOptions;
 
         foreach ($assetSourceOptions as $optionName => $optionValue) {
             switch ($optionName) {
@@ -150,27 +144,16 @@ class CantoAssetSource implements AssetSourceInterface
         }
     }
 
-    /**
-     * @param string $assetSourceIdentifier
-     * @param array $assetSourceOptions
-     * @return AssetSourceInterface
-     */
     public static function createFromConfiguration(string $assetSourceIdentifier, array $assetSourceOptions): AssetSourceInterface
     {
         return new static($assetSourceIdentifier, $assetSourceOptions);
     }
 
-    /**
-     * @return string
-     */
     public function getIdentifier(): string
     {
         return $this->assetSourceIdentifier;
     }
 
-    /**
-     * @return string
-     */
     public function getLabel(): string
     {
         return 'Canto';
@@ -188,49 +171,31 @@ class CantoAssetSource implements AssetSourceInterface
         return $this->assetProxyRepository;
     }
 
-    /**
-     * @return bool
-     */
     public function isReadOnly(): bool
     {
         return true;
     }
 
-    /**
-     * @return array
-     */
     public function getAssetSourceOptions(): array
     {
         return $this->assetSourceOptions;
     }
 
-    /**
-     * @return bool
-     */
     public function isAutoTaggingEnabled(): bool
     {
         return $this->autoTaggingEnabled;
     }
 
-    /**
-     * @return string
-     */
     public function getAutoTaggingInUseTag(): string
     {
         return $this->autoTaggingInUseTag;
     }
 
-    /**
-     * @return string
-     */
     public function getIconUri(): string
     {
         return $this->resourceManager->getPublicPackageResourceUriByPath($this->iconPath);
     }
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return $this->description;
@@ -251,9 +216,6 @@ class CantoAssetSource implements AssetSourceInterface
         return $this->appSecret;
     }
 
-    /**
-     * @return CantoClient
-     */
     public function getCantoClient(): CantoClient
     {
         if ($this->cantoClient === null) {

--- a/Classes/Command/CantoCommandController.php
+++ b/Classes/Command/CantoCommandController.php
@@ -58,7 +58,6 @@ class CantoCommandController extends CommandController
      *
      * @param string $assetSource Name of the canto asset source
      * @param bool $quiet If set, only errors will be displayed.
-     * @return void
      * @throws StopCommandException
      */
     public function tagUsedAssetsCommand(string $assetSource = CantoAssetSource::ASSET_SOURCE_IDENTIFIER, bool $quiet = false): void
@@ -129,7 +128,6 @@ class CantoCommandController extends CommandController
      *
      * @param string $assetSourceIdentifier Name of the canto asset source
      * @param bool $quiet If set, only errors will be displayed.
-     * @return void
      * @throws GuzzleException
      * @throws IllegalObjectTypeException
      * @throws OAuthClientException
@@ -151,7 +149,7 @@ class CantoCommandController extends CommandController
             $cantoAssetSource = $this->assetSourceService->getAssetSources()[$assetSourceIdentifier];
             $cantoClient = $cantoAssetSource->getCantoClient();
             $cantoClient->allowClientCredentialsAuthentication(true);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->outputLine('<error>Canto client could not be created</error>');
             $this->quit(1);
         }

--- a/Classes/Controller/CantoController.php
+++ b/Classes/Controller/CantoController.php
@@ -28,7 +28,6 @@ class CantoController extends AbstractModuleController
     protected $assetSourceService;
 
     /**
-     * @return void
      * @throws
      */
     public function indexAction(): void

--- a/Classes/Domain/Model/AccountAuthorization.php
+++ b/Classes/Domain/Model/AccountAuthorization.php
@@ -32,33 +32,21 @@ class AccountAuthorization
      */
     protected $authorizationId;
 
-    /**
-     * @return string
-     */
     public function getFlowAccountIdentifier(): string
     {
         return $this->flowAccountIdentifier;
     }
 
-    /**
-     * @param string $flowAccountIdentifier
-     */
     public function setFlowAccountIdentifier(string $flowAccountIdentifier): void
     {
         $this->flowAccountIdentifier = $flowAccountIdentifier;
     }
 
-    /**
-     * @return string
-     */
     public function getAuthorizationId(): string
     {
         return $this->authorizationId;
     }
 
-    /**
-     * @param string $authorizationId
-     */
     public function setAuthorizationId(string $authorizationId): void
     {
         $this->authorizationId = $authorizationId;

--- a/Classes/Domain/Repository/AccountAuthorizationRepository.php
+++ b/Classes/Domain/Repository/AccountAuthorizationRepository.php
@@ -22,10 +22,6 @@ use Neos\Flow\Persistence\Repository;
  */
 class AccountAuthorizationRepository extends Repository
 {
-    /**
-     * @param string $accountIdentifier
-     * @return AccountAuthorization|null
-     */
     public function findOneByFlowAccountIdentifier(string $accountIdentifier): ?AccountAuthorization
     {
         return $this->__call('findOneByFlowAccountIdentifier', [$accountIdentifier]);

--- a/Classes/Middleware/WebhookMiddleware.php
+++ b/Classes/Middleware/WebhookMiddleware.php
@@ -53,7 +53,7 @@ class WebhookMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $requestedPath = $request->getUri()->getPath();
-        if (strpos($requestedPath, $this->webhookPathPrefix) !== 0) {
+        if (!str_starts_with($requestedPath, $this->webhookPathPrefix)) {
             return $handler->handle($request);
         }
 
@@ -62,7 +62,7 @@ class WebhookMiddleware implements MiddlewareInterface
             if (!$this->validatePayload($payload)) {
                 return $this->responseFactory->createResponse(400, 'Invalid payload submitted');
             }
-        } catch (\JsonException $e) {
+        } catch (\JsonException) {
             return $this->responseFactory->createResponse(400, 'Invalid payload submitted, parse error');
         }
 

--- a/Classes/Service/AssetUpdateService.php
+++ b/Classes/Service/AssetUpdateService.php
@@ -121,7 +121,7 @@ final class AssetUpdateService
             $this->persistenceManager->persistAll();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
@@ -142,7 +142,7 @@ final class AssetUpdateService
             $this->persistenceManager->persistAll();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
@@ -195,9 +195,6 @@ final class AssetUpdateService
         }
     }
 
-    /**
-     * @return AssetSourceInterface|CantoAssetSource
-     */
     private function getAssetSource(): AssetSourceInterface
     {
         /** @var CantoAssetSource $assetSource */

--- a/Classes/Service/CantoClient.php
+++ b/Classes/Service/CantoClient.php
@@ -48,26 +48,6 @@ final class CantoClient
     protected bool $allowClientCredentialsAuthentication = false;
 
     /**
-     * @var string
-     */
-    private $apiBaseUri;
-
-    /**
-     * @var string
-     */
-    protected $appId;
-
-    /**
-     * @var string
-     */
-    protected $appSecret;
-
-    /**
-     * @var string
-     */
-    private $serviceName;
-
-    /**
      * @Flow\Inject
      * @var Bootstrap
      */
@@ -107,13 +87,8 @@ final class CantoClient
      * @param string $appSecret
      * @param string $serviceName
      */
-    public function __construct(string $apiBaseUri, string $appId, string $appSecret, string $serviceName)
+    public function __construct(private string $apiBaseUri, protected string $appId, protected string $appSecret, private string $serviceName)
     {
-        $this->apiBaseUri = $apiBaseUri;
-        $this->appId = $appId;
-        $this->appSecret = $appSecret;
-        $this->serviceName = $serviceName;
-
         $this->httpClient = new Client(['allow_redirects' => true]);
     }
 
@@ -173,7 +148,7 @@ final class CantoClient
             return $rh->getHttpRequest()->getUri();
         }
 
-        throw new \RuntimeException(sprintf('Active request handler (%s) does not implement Neos\Flow\Http\HttpRequestHandlerInterface, could not determine request URI', get_class($rh)), 1632465274);
+        throw new \RuntimeException(sprintf('Active request handler (%s) does not implement Neos\Flow\Http\HttpRequestHandlerInterface, could not determine request URI', $rh::class), 1632465274);
     }
 
     private function redirectToUri(string $uri): void
@@ -183,8 +158,6 @@ final class CantoClient
     }
 
     /**
-     * @param string $assetProxyId
-     * @return ResponseInterface
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException
@@ -200,9 +173,6 @@ final class CantoClient
     }
 
     /**
-     * @param string $id
-     * @param array $metadata
-     * @return ResponseInterface
      * @TODO Implement updateFile() method.
      */
     public function updateFile(string $id, array $metadata): ResponseInterface
@@ -211,13 +181,6 @@ final class CantoClient
     }
 
     /**
-     * @param string $keyword
-     * @param array $formatTypes
-     * @param string $customQueryPart
-     * @param int $offset
-     * @param int $limit
-     * @param array $orderings
-     * @return ResponseInterface
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException
@@ -255,7 +218,6 @@ final class CantoClient
     }
 
     /**
-     * @return array
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException
@@ -275,7 +237,6 @@ final class CantoClient
     }
 
     /**
-     * @return array
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException
@@ -294,7 +255,6 @@ final class CantoClient
     }
 
     /**
-     * @return array
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException
@@ -313,8 +273,6 @@ final class CantoClient
     }
 
     /**
-     * @param string $assetProxyId
-     * @return Uri|null
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException
@@ -362,7 +320,6 @@ final class CantoClient
      * @param string $uriPathAndQuery A relative URI of the web server, prepended by the base URI
      * @param string $method The HTTP method, for example "GET" or "POST"
      * @param array $bodyFields Associative array of body fields to send (optional)
-     * @return RequestInterface
      * @throws OAuthClientException
      */
     private function getAuthenticatedRequest(Authorization $authorization, string $uriPathAndQuery, string $method = 'GET', array $bodyFields = []): RequestInterface
@@ -386,10 +343,6 @@ final class CantoClient
     /**
      * Sends an HTTP request to an OAuth 2.0 service provider using Bearer token authentication
      *
-     * @param string $uriPathAndQuery
-     * @param string $method
-     * @param array $bodyFields
-     * @return Response
      * @throws AuthenticationFailedException
      * @throws GuzzleException
      * @throws HttpException

--- a/Classes/Service/CantoClient.php
+++ b/Classes/Service/CantoClient.php
@@ -227,6 +227,31 @@ final class CantoClient
      * @throws OAuthClientException
      * @todo perhaps cache the result
      */
+    public function getFacetValues(string $facetName): array
+    {
+        $response = $this->sendAuthenticatedRequest('search');
+        if ($response->getStatusCode() === 200) {
+            $result = \GuzzleHttp\json_decode($response->getBody()->getContents(), true);
+
+            foreach ($result['facets'] as $facet) {
+                if ($facet['name'] === $facetName) {
+                    return $facet['value'];
+                }
+            }
+        }
+        return [];
+    }
+
+    /**
+     * @throws AuthenticationFailedException
+     * @throws GuzzleException
+     * @throws HttpException
+     * @throws IdentityProviderException
+     * @throws MissingActionNameException
+     * @throws MissingClientSecretException
+     * @throws OAuthClientException
+     * @todo perhaps cache the result
+     */
     public function getCustomFields(): array
     {
         $response = $this->sendAuthenticatedRequest('custom/field');

--- a/Classes/Service/CantoOAuthClient.php
+++ b/Classes/Service/CantoOAuthClient.php
@@ -51,7 +51,7 @@ class CantoOAuthClient extends OAuthClient
      */
     protected $accountAuthorizationRepository;
 
-    public function getServiceType(): string
+    public static function getServiceType(): string
     {
         return CantoAssetSource::ASSET_SOURCE_IDENTIFIER;
     }

--- a/Classes/Service/CantoOAuthProvider.php
+++ b/Classes/Service/CantoOAuthProvider.php
@@ -27,7 +27,6 @@ final class CantoOAuthProvider extends GenericProvider
      * Requests an access token using a specified grant and option set.
      *
      * @param mixed $grant
-     * @param array $options
      * @return AccessTokenInterface
      * @throws IdentityProviderException
      */

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -3,3 +3,9 @@ Flownative_Canto_AssetProxy:
   backend: Neos\Cache\Backend\FileBackend
   backendOptions:
     defaultLifetime: 0
+
+Flownative_Canto_AssetProxyRepository:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend
+  backendOptions:
+    defaultLifetime: 3600

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -8,6 +8,16 @@ Flownative\Canto\AssetSource\CantoAssetSource:
           1:
             value: Flownative_Canto_AssetProxy
 
+Flownative\Canto\AssetSource\CantoAssetProxyRepository:
+  properties:
+    assetProxyRepositoryCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Flownative_Canto_AssetProxyRepository
+
 Flownative\Canto\Service\CantoOAuthClient:
   properties:
     stateCache:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,8 +1,15 @@
 Flownative:
   Canto:
+    # At the moment, this is "either or", so use custom fields or tags for mapping, not both
     mapping:
       # map "Custom Fields" from Canto to Neos
       customFields: []
+      # map "Tags" from Canto to Neos
+      tags:
+        field: 'tags'
+        limit: 20
+        include: []
+        exclude: ['Untagged']
     webhook:
       pathPrefix: '/flownative-canto/webhook/'
       # A token that can be used to secure webhook invocations; used only if set

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "neos/flow": "^8.0 || dev-master",
         "neos/media": "^8.0 || dev-master",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "behat/transliterator": "~1.0",
         "flownative/oauth2-client": "^4.0.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "name": "flownative/neos-canto",
     "license": "MIT",
     "require": {
-        "php": "^7.4",
+        "php": "^8.0",
         "ext-json": "*",
-        "neos/flow": "^5.3 || ^6.0 || ^7.0 || dev-master",
-        "neos/media": "^4.3 || ^5.0 || ^7.0 || dev-master",
-        "guzzlehttp/guzzle": "6.*",
+        "neos/flow": "^8.0 || dev-master",
+        "neos/media": "^8.0 || dev-master",
+        "guzzlehttp/guzzle": "^7.0",
         "behat/transliterator": "~1.0",
-        "flownative/oauth2-client": "^2.2 || ^3.4"
+        "flownative/oauth2-client": "^4.0.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Info, this is based on the PHP8-compatible PR from @markusguenther.

This PR adds the feature to use actual Canto tags instead of custom fields to use in the media browser. I don't know if you need/want this, or if there were any reasons to omit this feature and use custom fields in the first place.

It is configurable, similar to the custom fields mapping:

```
Flownative:
  Canto:
    # At the moment, this is "either or", so use custom fields or tags for mapping, not both
    mapping:
      # map "Custom Fields" from Canto to Neos
      customFields: []
      # map "Tags" from Canto to Neos
      tags:
        field: 'tags'
        limit: 20
        include: []
        exclude: ['Untagged']
```

Asset count per tag is cached for performance reasons for one hour.

A new CLI command "importtags" can be used to import the tags first, then they are shown in the media browser.