### PR TITLE
FEATURE: Implement actual Canto tags to be used as Neos tags

### DIFF
--- a/Classes/AssetSource/CantoAssetProxyQuery.php
+++ b/Classes/AssetSource/CantoAssetProxyQuery.php
@@ -248,6 +248,10 @@ final class CantoAssetProxyQuery implements AssetProxyQueryInterface
                 }
             }
         }
+
+        if (!empty($this->mapping['tags'])) {
+            $this->tagQuery .= '&tags="' . $this->activeTag->getLabel() . '"';
+        }
     }
 
     /**

--- a/Classes/Command/CantoCommandController.php
+++ b/Classes/Command/CantoCommandController.php
@@ -207,4 +207,60 @@ class CantoCommandController extends CommandController
 
         !$quiet && $this->outputLine('<success>Import done.</success>');
     }
+
+    /**
+     * Import Canto Tags as Tags
+     *
+     * @param string $assetSourceIdentifier Name of the canto asset source
+     * @param bool $quiet If set, only errors will be displayed.
+     * @throws GuzzleException
+     * @throws IllegalObjectTypeException
+     * @throws OAuthClientException
+     * @throws StopCommandException
+     * @throws AuthenticationFailedException
+     */
+    public function importTagsCommand(string $assetSourceIdentifier = CantoAssetSource::ASSET_SOURCE_IDENTIFIER, bool $quiet = true): void
+    {
+        !$quiet && $this->outputLine('<b>Importing tags via Canto API</b>');
+
+        $tagMapping = $this->mapping['tags'];
+        if (empty($tagMapping)) {
+            $this->outputLine('<error>No tags mapping configured</error>');
+            $this->quit(1);
+        }
+
+        try {
+            /** @var CantoAssetSource $cantoAssetSource */
+            $cantoAssetSource = $this->assetSourceService->getAssetSources()[$assetSourceIdentifier];
+            $cantoClient = $cantoAssetSource->getCantoClient();
+            $cantoClient->allowClientCredentialsAuthentication(true);
+        } catch (\Exception) {
+            $this->outputLine('<error>Canto client could not be created</error>');
+            $this->quit(1);
+        }
+
+        $tags = $cantoClient->getFacetValues($tagMapping['field']);
+        $relevantTags = array_chunk($tags, $tagMapping['limit']);
+        foreach ($relevantTags[0] as $tagLabel) {
+
+            if (!empty($tagMapping['include']) && !in_array($tagLabel, $tagMapping['include'], true)) {
+                continue;
+            }
+            if (!empty($tagMapping['exclude']) && in_array($tagLabel, $tagMapping['exclude'], true)) {
+                continue;
+            }
+
+            $tag = $this->tagRepository->findOneByLabel($tagLabel);
+
+            if ($tag === null) {
+                $tag = new Tag($tagLabel);
+                $this->tagRepository->add($tag);
+                !$quiet && $this->outputLine('  + %s', [$tagLabel]);
+            }
+
+            !$quiet && $this->outputLine();
+        }
+
+        !$quiet && $this->outputLine('<success>Import done.</success>');
+    }
 }

--- a/Classes/Service/CantoClient.php
+++ b/Classes/Service/CantoClient.php
@@ -248,6 +248,31 @@ final class CantoClient
      * @throws MissingActionNameException
      * @throws MissingClientSecretException
      * @throws OAuthClientException
+     * @todo perhaps cache the result
+     */
+    public function getFacetValues(string $facetName): array
+    {
+        $response = $this->sendAuthenticatedRequest('search');
+        if ($response->getStatusCode() === 200) {
+            $result = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+
+            foreach ($result['facets'] as $facet) {
+                if ($facet['name'] === $facetName) {
+                    return $facet['value'];
+                }
+            }
+        }
+        return [];
+    }
+
+    /**
+     * @throws AuthenticationFailedException
+     * @throws GuzzleException
+     * @throws HttpException
+     * @throws IdentityProviderException
+     * @throws MissingActionNameException
+     * @throws MissingClientSecretException
+     * @throws OAuthClientException
      * @throws \JsonException
      */
     public function user(): array

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,8 +1,15 @@
 Flownative:
   Canto:
+    # At the moment, this is "either or", so use custom fields or tags for mapping, not both
     mapping:
       # map "Custom Fields" from Canto to Neos
       customFields: []
+      # map "Tags" from Canto to Neos
+      tags:
+        field: 'tags'
+        limit: 20
+        include: []
+        exclude: ['Untagged']
     webhook:
       pathPrefix: '/flownative-canto/webhook/'
       # A token that can be used to secure webhook invocations; used only if set


### PR DESCRIPTION
This PR adds the feature to use actual Canto tags instead of custom fields to use in the media browser. I don't know if you need/want this, or if there were any reasons to omit this feature and use custom fields in the first place.

It is configurable, similar to the custom fields mapping:

```
Flownative:
  Canto:
    # At the moment, this is "either or", so use custom fields or tags for mapping, not both
    mapping:
      # map "Custom Fields" from Canto to Neos
      customFields: []
      # map "Tags" from Canto to Neos
      tags:
        field: 'tags'
        limit: 20
        include: []
        exclude: ['Untagged']
```

Asset count per tag is cached for performance reasons for one hour.

A new CLI command "importtags" can be used to import the tags first, then they are shown in the media browser.