### PR TITLE
TASK: compatibility with Neos 9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "neos/flow": "7.0 || ^8.0 || ^9.0 || dev-master",
-        "neos/media": "^7.0 || ^8.0 || ^9.0 || dev-master",
+        "neos/flow": "7.0 || ^8.0 || ^9.0 || dev-main",
+        "neos/media": "^7.0 || ^8.0 || ^9.0 || dev-main",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "behat/transliterator": "~1.0",
         "flownative/oauth2-client": "^4.0.2"

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "neos/flow": "7.0 || ^8.0 || dev-master",
-        "neos/media": "^7.0 || ^8.0 || dev-master",
+        "neos/flow": "7.0 || ^8.0 || ^9.0 || dev-master",
+        "neos/media": "^7.0 || ^8.0 || ^9.0 || dev-master",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "behat/transliterator": "~1.0",
         "flownative/oauth2-client": "^4.0.2"


### PR DESCRIPTION
For updating to Neos 9.0 the version needs to be updated.

As far as I can see on my local machine the package works fine with Neos 9.0. Perhaps someone else can verify with a Neos 9.0 installation.