### PR TITLE
BUGFIX: do not fail, if no tag property is present

### DIFF
--- a/Classes/AssetSource/CantoAssetProxy.php
+++ b/Classes/AssetSource/CantoAssetProxy.php
@@ -81,7 +81,7 @@ final class CantoAssetProxy implements AssetProxyInterface, HasRemoteOriginalInt
         $assetProxy->lastModified = \DateTime::createFromFormat('YmdHisv', $jsonObject->default->{'Date modified'});
         $assetProxy->fileSize = (int)$jsonObject->size;
         $assetProxy->mediaType = MediaTypes::getMediaTypeFromFilename($jsonObject->name);
-        $assetProxy->tags = $jsonObject->tag ? (array)$jsonObject->tag : [];
+        $assetProxy->tags = isset($jsonObject->tag) ? (array)$jsonObject->tag : [];
 
         $assetProxy->iptcProperties['CopyrightNotice'] = $jsonObject->copyright ?? ($jsonObject->default->Copyright ?? '');
 


### PR DESCRIPTION
resolves: #35 

Make the code more robust, if there is no 'tag' property/ key present.